### PR TITLE
デザインのupdate #22

### DIFF
--- a/masterch.xcodeproj/project.pbxproj
+++ b/masterch.xcodeproj/project.pbxproj
@@ -64,14 +64,11 @@
 		ED3C035E1DC3AEE10041C450 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED3C035D1DC3AEE10041C450 /* MapKit.framework */; };
 		ED402DCC1D34460C0098F843 /* images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ED402DCB1D34460C0098F843 /* images.xcassets */; };
 		ED4512B01CEF33CB0071FA58 /* Title.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ED4512AF1CEF33CB0071FA58 /* Title.storyboard */; };
-		ED48C92D1D4D0120003DC586 /* TTTAttributedLabel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED48C92C1D4D0120003DC586 /* TTTAttributedLabel.framework */; };
 		ED48C9321D4D069E003DC586 /* TTTAttributedLabel.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = ED48C9301D4D069E003DC586 /* TTTAttributedLabel.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		ED48C9481D4F67B9003DC586 /* pushManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED48C9471D4F67B9003DC586 /* pushManager.swift */; };
 		ED5274EB1D23CD2D0088481F /* LogPostedProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED5274EA1D23CD2D0088481F /* LogPostedProgressBar.swift */; };
 		ED53BAFD1D35176F0089A03A /* GoodOrBadKeyboard.xib in Resources */ = {isa = PBXBuildFile; fileRef = ED53BAFC1D35176F0089A03A /* GoodOrBadKeyboard.xib */; };
 		ED652C4C1D29C2B60004BE9F /* MainTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED652C4B1D29C2B60004BE9F /* MainTabViewController.swift */; };
-		ED6AF8CA1D16B535003FBC5C /* DropdownMenu.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED6AF8C91D16B535003FBC5C /* DropdownMenu.framework */; };
-		ED6AF8CB1D16B535003FBC5C /* DropdownMenu.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = ED6AF8C91D16B535003FBC5C /* DropdownMenu.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		ED6AF8CD1D16B577003FBC5C /* SVProgressHUD.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED6AF8CC1D16B577003FBC5C /* SVProgressHUD.framework */; };
 		ED6AF8CE1D16B577003FBC5C /* SVProgressHUD.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = ED6AF8CC1D16B577003FBC5C /* SVProgressHUD.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		ED6ED06D1D387ACD005B0053 /* GCDManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6ED06C1D387ACD005B0053 /* GCDManager.swift */; };
@@ -86,6 +83,7 @@
 		ED7A79051D2027220087BCCD /* DZNEmptyDataSet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED7A79041D2027220087BCCD /* DZNEmptyDataSet.framework */; };
 		ED7A79061D2027220087BCCD /* DZNEmptyDataSet.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = ED7A79041D2027220087BCCD /* DZNEmptyDataSet.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		ED8322D41C8EFDF700122BA2 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8322D31C8EFDF700122BA2 /* SignUpViewController.swift */; };
+		ED9366C11DEC559A00CBBF36 /* TTTAttributedLabel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED48C9301D4D069E003DC586 /* TTTAttributedLabel.framework */; };
 		ED97606F1DA7B9220002E62D /* LookBackDayTitleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED97606E1DA7B9220002E62D /* LookBackDayTitleManager.swift */; };
 		EDA49FEE1D9E5B4D006C2605 /* LookBackQueryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA49FED1D9E5B4D006C2605 /* LookBackQueryManager.swift */; };
 		EDA49FF01D9E6354006C2605 /* LooKBackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA49FEF1D9E6354006C2605 /* LooKBackViewController.swift */; };
@@ -140,7 +138,6 @@
 			files = (
 				ED48C9321D4D069E003DC586 /* TTTAttributedLabel.framework in CopyFiles */,
 				ED6AF8CE1D16B577003FBC5C /* SVProgressHUD.framework in CopyFiles */,
-				ED6AF8CB1D16B535003FBC5C /* DropdownMenu.framework in CopyFiles */,
 				ED7A79061D2027220087BCCD /* DZNEmptyDataSet.framework in CopyFiles */,
 				ED779B0C1C8ED0F700C3027C /* SwiftDate.framework in CopyFiles */,
 			);
@@ -224,13 +221,11 @@
 		ED3C035D1DC3AEE10041C450 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		ED402DCB1D34460C0098F843 /* images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = images.xcassets; sourceTree = "<group>"; };
 		ED4512AF1CEF33CB0071FA58 /* Title.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Title.storyboard; sourceTree = "<group>"; };
-		ED48C92C1D4D0120003DC586 /* TTTAttributedLabel.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = TTTAttributedLabel.framework; path = /Users/gucchi/Desktop/masterch/masterch/TTTAttributedLabel.framework; sourceTree = "<absolute>"; };
 		ED48C9301D4D069E003DC586 /* TTTAttributedLabel.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = TTTAttributedLabel.framework; path = Carthage/Build/iOS/TTTAttributedLabel.framework; sourceTree = "<group>"; };
 		ED48C9471D4F67B9003DC586 /* pushManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = pushManager.swift; sourceTree = "<group>"; };
 		ED5274EA1D23CD2D0088481F /* LogPostedProgressBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogPostedProgressBar.swift; sourceTree = "<group>"; };
 		ED53BAFC1D35176F0089A03A /* GoodOrBadKeyboard.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = GoodOrBadKeyboard.xib; sourceTree = "<group>"; };
 		ED652C4B1D29C2B60004BE9F /* MainTabViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainTabViewController.swift; sourceTree = "<group>"; };
-		ED6AF8C91D16B535003FBC5C /* DropdownMenu.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DropdownMenu.framework; path = Carthage/Build/iOS/DropdownMenu.framework; sourceTree = "<group>"; };
 		ED6AF8CC1D16B577003FBC5C /* SVProgressHUD.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SVProgressHUD.framework; path = Carthage/Build/iOS/SVProgressHUD.framework; sourceTree = "<group>"; };
 		ED6ED06C1D387ACD005B0053 /* GCDManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GCDManager.swift; sourceTree = "<group>"; };
 		ED6F08071DA3E25000606295 /* CalendarLogColorCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalendarLogColorCache.swift; sourceTree = "<group>"; };
@@ -275,14 +270,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ED9366C11DEC559A00CBBF36 /* TTTAttributedLabel.framework in Frameworks */,
 				ED3C035E1DC3AEE10041C450 /* MapKit.framework in Frameworks */,
 				ED3C035C1DC3AD100041C450 /* CoreLocation.framework in Frameworks */,
 				ED08F2531DC229F800C8CB54 /* Photos.framework in Frameworks */,
 				ED779B0A1C8DCB9100C3027C /* SwiftDate.framework in Frameworks */,
-				ED48C92D1D4D0120003DC586 /* TTTAttributedLabel.framework in Frameworks */,
 				ED6AF8CD1D16B577003FBC5C /* SVProgressHUD.framework in Frameworks */,
 				ED7A79051D2027220087BCCD /* DZNEmptyDataSet.framework in Frameworks */,
-				ED6AF8CA1D16B535003FBC5C /* DropdownMenu.framework in Frameworks */,
 				C723D0368844C8137A7AB044 /* Pods_masterch.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -396,7 +390,6 @@
 				ED08F2521DC229F800C8CB54 /* Photos.framework */,
 				ED48C9301D4D069E003DC586 /* TTTAttributedLabel.framework */,
 				ED7A79041D2027220087BCCD /* DZNEmptyDataSet.framework */,
-				ED6AF8C91D16B535003FBC5C /* DropdownMenu.framework */,
 				ED6AF8CC1D16B577003FBC5C /* SVProgressHUD.framework */,
 				ED779B091C8DCB9100C3027C /* SwiftDate.framework */,
 				E600DCFEE36D4763CBA1FFBF /* Pods_masterch.framework */,
@@ -597,6 +590,7 @@
 				32C0A3381C5DF8ED009657B9 /* Resources */,
 				ED779B0B1C8ED0D300C3027C /* CopyFiles */,
 				ED8FE1CB1C8FE62200CFD685 /* ShellScript */,
+				ED9366C21DEC57DC00CBBF36 /* ShellScript */,
 				B8A26049C56D2BF01088C609 /* [CP] Embed Pods Frameworks */,
 				C0A1DA4F142BF0175A1A60DB /* [CP] Copy Pods Resources */,
 			);
@@ -883,13 +877,29 @@
 			files = (
 			);
 			inputPaths = (
-				"",
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Fabric/run\" ec62d35d0015bc60b374384a4991ee3316538e74 aa24872d7a2760b27c0cdd2434421b127640c6c7490b706db95f3d8178ef4cdf";
+		};
+		ED9366C21DEC57DC00CBBF36 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/SwiftDate.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/SVProgressHUD.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/DZNEmptyDataSet.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/TTTAttributedLabel.framework",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1034,6 +1044,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer: Hiroki Taniguchi (RA9N5B6XBR)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Hiroki Taniguchi (RA9N5B6XBR)";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1056,7 +1067,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				PROVISIONING_PROFILE = "83d9f495-3e67-40ab-8dfa-e0c50a0e0f53";
+				PROVISIONING_PROFILE = "9bc14cf0-4d0a-4094-b5c8-34f1a9814f26";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -1079,6 +1090,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer: Hiroki Taniguchi (RA9N5B6XBR)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Hiroki Taniguchi (RA9N5B6XBR)";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -1094,7 +1106,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PROVISIONING_PROFILE = "83d9f495-3e67-40ab-8dfa-e0c50a0e0f53";
+				PROVISIONING_PROFILE = "9bc14cf0-4d0a-4094-b5c8-34f1a9814f26";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};

--- a/masterch/Account.storyboard
+++ b/masterch/Account.storyboard
@@ -604,7 +604,7 @@
                                                     </variation>
                                                 </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="LHL-0J-yxM">
-                                                    <rect key="frame" x="8" y="120" width="304" height="150"/>
+                                                    <rect key="frame" x="0.0" y="120" width="320" height="150"/>
                                                     <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="150" id="3yC-Hf-m0B"/>
@@ -707,14 +707,14 @@
                                                 <constraint firstItem="u0u-Dh-cvt" firstAttribute="leading" secondItem="lZY-P3-doC" secondAttribute="trailing" constant="8" id="DcT-XG-veb"/>
                                                 <constraint firstItem="zhz-ld-oHe" firstAttribute="leading" secondItem="FFn-kp-Epu" secondAttribute="leading" constant="8" id="DlA-Gh-fbV"/>
                                                 <constraint firstItem="QCT-pl-iwx" firstAttribute="leading" secondItem="FFn-kp-Epu" secondAttribute="leading" constant="8" id="Lne-9A-Jce"/>
-                                                <constraint firstAttribute="trailing" secondItem="LHL-0J-yxM" secondAttribute="trailing" constant="8" id="MuF-Iw-lyN"/>
+                                                <constraint firstAttribute="trailing" secondItem="LHL-0J-yxM" secondAttribute="trailing" id="MuF-Iw-lyN"/>
                                                 <constraint firstItem="lZY-P3-doC" firstAttribute="top" secondItem="LHL-0J-yxM" secondAttribute="bottom" constant="12" id="P3h-UO-TgE"/>
                                                 <constraint firstItem="u0u-Dh-cvt" firstAttribute="width" secondItem="lZY-P3-doC" secondAttribute="width" id="TNr-pB-IZl"/>
                                                 <constraint firstItem="LHL-0J-yxM" firstAttribute="top" secondItem="QCT-pl-iwx" secondAttribute="bottom" constant="8" id="Vru-mz-riI"/>
                                                 <constraint firstAttribute="trailingMargin" secondItem="HEn-jo-GzK" secondAttribute="trailing" constant="8" id="cLd-eN-VXB"/>
                                                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="lZY-P3-doC" secondAttribute="bottom" constant="8" id="d3l-f9-9q3"/>
                                                 <constraint firstItem="HEn-jo-GzK" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="gLE-Yt-jRQ" secondAttribute="trailing" constant="8" id="fsC-Ik-J0h"/>
-                                                <constraint firstItem="LHL-0J-yxM" firstAttribute="leading" secondItem="FFn-kp-Epu" secondAttribute="leading" constant="8" id="nFV-OS-3cc"/>
+                                                <constraint firstItem="LHL-0J-yxM" firstAttribute="leading" secondItem="FFn-kp-Epu" secondAttribute="leading" id="nFV-OS-3cc"/>
                                                 <constraint firstItem="HEn-jo-GzK" firstAttribute="centerY" secondItem="gLE-Yt-jRQ" secondAttribute="centerY" id="rWv-8G-XRz"/>
                                                 <constraint firstItem="gLE-Yt-jRQ" firstAttribute="leading" secondItem="zhz-ld-oHe" secondAttribute="trailing" constant="6" id="u4h-oL-i8i"/>
                                                 <constraint firstItem="u0u-Dh-cvt" firstAttribute="centerY" secondItem="lZY-P3-doC" secondAttribute="centerY" id="vkH-Mb-n08"/>
@@ -1547,7 +1547,7 @@ version更新をお待ち下さい。
         <image name="hartButton_On.png" width="23" height="21"/>
         <image name="hartOFF" width="25" height="22"/>
         <image name="noprofile" width="400" height="400"/>
-        <image name="noprofile.png" width="137" height="150"/>
+        <image name="noprofile.png" width="561" height="567"/>
         <image name="tabAccount" width="30" height="27"/>
         <image name="twitterWhite" width="40" height="33"/>
     </resources>

--- a/masterch/AccountViewController.swift
+++ b/masterch/AccountViewController.swift
@@ -473,7 +473,7 @@ extension AccountViewController: UITableViewDelegate, UITableViewDataSource, TTT
             cell.postImageView.image = nil
             if let postImageName = postData.objectForKey("image1") as? String {
                 cell.imageViewHeightConstraint.constant = 150.0
-                cell.postImageView.layer.cornerRadius = 5.0
+//                cell.postImageView.layer.cornerRadius = 5.0
                 let postImageFile = NCMBFile.fileWithName(postImageName, data: nil) as! NCMBFile
                 SDWebImageManager.sharedManager().imageCache.queryDiskCacheForKey(postImageFile.name, done: { (image, SDImageCacheType) in
                     if let image = image {

--- a/masterch/Base.lproj/Main.storyboard
+++ b/masterch/Base.lproj/Main.storyboard
@@ -39,8 +39,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="📸カメラロールを連携しよう！📸" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="muX-Mu-uEU">
-                                <rect key="frame" x="53" y="120" width="306" height="24"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="📸カメラロールを連携しよう！📸" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="muX-Mu-uEU">
+                                <rect key="frame" x="54" y="120" width="306" height="24"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -490,6 +490,7 @@
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="contactAdd" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G4O-ws-LgW" userLabel="editUserProfileButton">
                                 <rect key="frame" x="20" y="94" width="100" height="100"/>
+                                <color key="tintColor" red="0.21480557319999999" green="0.80131393669999995" blue="0.37377047540000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <connections>
                                     <action selector="selectEditProfileImageButton:" destination="iJy-WC-FCV" eventType="touchUpInside" id="goI-4h-hTE"/>
                                 </connections>
@@ -795,6 +796,6 @@
         <image name="tw_login_small.png" width="261" height="58"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="L8J-Kv-eM2"/>
+        <segue reference="d3l-QJ-9PL"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/masterch/CommentTableViewCell.xib
+++ b/masterch/CommentTableViewCell.xib
@@ -84,6 +84,6 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="noprofile.png" width="500" height="500"/>
+        <image name="noprofile.png" width="561" height="567"/>
     </resources>
 </document>

--- a/masterch/Info.plist
+++ b/masterch/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4</string>
+	<string>1.5</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/masterch/Log.storyboard
+++ b/masterch/Log.storyboard
@@ -51,44 +51,37 @@
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="日" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fiX-kn-XmQ">
                                                 <rect key="frame" x="0.0" y="4" width="45" height="17"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="月" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ls9-il-zMK">
                                                 <rect key="frame" x="45" y="4" width="44" height="17"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="火" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gP6-Na-cf2">
                                                 <rect key="frame" x="89" y="4" width="45" height="17"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="水" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g6a-cb-s7y">
                                                 <rect key="frame" x="133" y="4" width="44" height="17"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="木" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ib2-IB-urJ">
                                                 <rect key="frame" x="177" y="4" width="45" height="17"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="金" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBK-fV-FbH">
                                                 <rect key="frame" x="222" y="4" width="44" height="17"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="土" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xko-XU-yGl">
                                                 <rect key="frame" x="266" y="4" width="45" height="17"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
@@ -116,7 +109,6 @@
                                         </variation>
                                     </stackView>
                                 </subviews>
-                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstItem="nvG-ZK-mYt" firstAttribute="leading" secondItem="tsQ-Wi-OFt" secondAttribute="leading" constant="5" id="6Yd-Gc-3mq"/>
                                     <constraint firstAttribute="trailing" secondItem="nvG-ZK-mYt" secondAttribute="trailing" constant="5" id="7hi-0q-ZWM"/>
@@ -127,14 +119,14 @@
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2fc-Zq-whP" userLabel="Calendar Week View">
                                 <rect key="frame" x="5" y="138" width="310" height="44.5"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="2fc-Zq-whP" secondAttribute="height" multiplier="7:1" id="Lgz-iO-7RP"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2PW-2V-byW" userLabel="Calendar Base View">
                                 <rect key="frame" x="5" y="138" width="310" height="265"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="2PW-2V-byW" secondAttribute="height" multiplier="7:6" id="4Pg-BG-NZy"/>
                                 </constraints>
@@ -167,7 +159,7 @@
                                                     </variation>
                                                 </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="EL9-md-m6U">
-                                                    <rect key="frame" x="8" y="120" width="304" height="150"/>
+                                                    <rect key="frame" x="0.0" y="120" width="320" height="150"/>
                                                     <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="150" id="tyc-5F-3XU"/>
@@ -265,16 +257,17 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstItem="eEx-X2-0YL" firstAttribute="leading" secondItem="8gM-WE-b7p" secondAttribute="leading" constant="8" id="3Jy-JP-hob"/>
                                                 <constraint firstAttribute="trailing" secondItem="qUm-qe-xvs" secondAttribute="trailing" constant="48" id="4MW-U3-PBT"/>
-                                                <constraint firstAttribute="trailing" secondItem="EL9-md-m6U" secondAttribute="trailing" constant="8" id="6VQ-HK-QZK"/>
+                                                <constraint firstAttribute="trailing" secondItem="EL9-md-m6U" secondAttribute="trailing" id="6VQ-HK-QZK"/>
                                                 <constraint firstItem="7gm-Fv-HJZ" firstAttribute="leading" secondItem="eEx-X2-0YL" secondAttribute="trailing" constant="6" id="8TN-5G-Db4"/>
                                                 <constraint firstItem="dlF-jG-gM4" firstAttribute="centerY" secondItem="kGz-eO-Vmi" secondAttribute="centerY" id="9yR-A4-l31"/>
                                                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="kGz-eO-Vmi" secondAttribute="bottom" constant="8" id="JhB-Dw-aVf"/>
                                                 <constraint firstItem="qUm-qe-xvs" firstAttribute="top" secondItem="dlF-jG-gM4" secondAttribute="top" id="NKA-FO-Oaj"/>
                                                 <constraint firstItem="bHn-we-dr0" firstAttribute="centerY" secondItem="7gm-Fv-HJZ" secondAttribute="centerY" id="Nhe-t7-SWQ"/>
-                                                <constraint firstItem="EL9-md-m6U" firstAttribute="leading" secondItem="8gM-WE-b7p" secondAttribute="leading" constant="8" id="OtU-tN-EdX"/>
+                                                <constraint firstItem="EL9-md-m6U" firstAttribute="leading" secondItem="8gM-WE-b7p" secondAttribute="leading" id="OtU-tN-EdX"/>
                                                 <constraint firstItem="qUm-qe-xvs" firstAttribute="centerY" secondItem="kGz-eO-Vmi" secondAttribute="centerY" id="Tbf-Wq-tmd"/>
                                                 <constraint firstItem="qUm-qe-xvs" firstAttribute="leading" secondItem="kGz-eO-Vmi" secondAttribute="trailing" constant="8" id="Ugb-0G-BUJ"/>
                                                 <constraint firstItem="bHn-we-dr0" firstAttribute="top" secondItem="eEx-X2-0YL" secondAttribute="top" id="cNp-Ud-Gxp"/>
@@ -319,6 +312,23 @@
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="213.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="pZs-b8-2Np">
+                                                    <rect key="frame" x="0.0" y="0.0" width="320" height="192"/>
+                                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="150" id="8j8-Hn-nca"/>
+                                                        <constraint firstAttribute="width" secondItem="pZs-b8-2Np" secondAttribute="height" multiplier="5:3" id="YoZ-fF-7Bz"/>
+                                                    </constraints>
+                                                    <variation key="default">
+                                                        <mask key="constraints">
+                                                            <exclude reference="8j8-Hn-nca"/>
+                                                        </mask>
+                                                    </variation>
+                                                </imageView>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cTi-TP-9y1">
+                                                    <rect key="frame" x="0.0" y="0.5" width="320" height="192"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.3990605828220859" colorSpace="calibratedRGB"/>
+                                                </view>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="noprofile" translatesAutoresizingMaskIntoConstraints="NO" id="XBU-7r-pwn">
                                                     <rect key="frame" x="8" y="8" width="40" height="40"/>
                                                     <constraints>
@@ -327,54 +337,35 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="カメラロール" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QTr-Q8-jXt">
-                                                    <rect key="frame" x="54" y="17.5" width="102" height="21"/>
+                                                    <rect key="frame" x="54" y="17" width="102" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="pZs-b8-2Np">
-                                                    <rect key="frame" x="8" y="56" width="304" height="150"/>
-                                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="150" id="8j8-Hn-nca"/>
-                                                    </constraints>
-                                                </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="count" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eMS-a0-w40">
-                                                    <rect key="frame" x="119" y="112.5" width="82.5" height="36"/>
+                                                    <rect key="frame" x="119" y="78" width="82.5" height="36"/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
                                                     <color key="textColor" red="0.21480557319999999" green="0.80131393669999995" blue="0.37377047540000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
+                                                <constraint firstItem="cTi-TP-9y1" firstAttribute="bottom" secondItem="pZs-b8-2Np" secondAttribute="bottom" id="1Na-QV-RxX"/>
                                                 <constraint firstItem="pZs-b8-2Np" firstAttribute="centerX" secondItem="K93-pH-Ba9" secondAttribute="centerX" id="2oA-x2-LML"/>
-                                                <constraint firstAttribute="trailing" secondItem="pZs-b8-2Np" secondAttribute="trailing" constant="8" id="9hj-lf-1eH"/>
+                                                <constraint firstAttribute="trailing" secondItem="pZs-b8-2Np" secondAttribute="trailing" id="9hj-lf-1eH"/>
                                                 <constraint firstItem="QTr-Q8-jXt" firstAttribute="leading" secondItem="XBU-7r-pwn" secondAttribute="trailing" constant="6" id="B0i-JJ-LYN"/>
-                                                <constraint firstItem="pZs-b8-2Np" firstAttribute="leading" secondItem="K93-pH-Ba9" secondAttribute="leading" constant="8" id="DU8-Fm-Jjp"/>
                                                 <constraint firstItem="QTr-Q8-jXt" firstAttribute="centerY" secondItem="XBU-7r-pwn" secondAttribute="centerY" id="G70-NF-oYk"/>
-                                                <constraint firstItem="pZs-b8-2Np" firstAttribute="leading" secondItem="K93-pH-Ba9" secondAttribute="leading" constant="8" id="GOt-ed-Khh"/>
+                                                <constraint firstItem="pZs-b8-2Np" firstAttribute="leading" secondItem="K93-pH-Ba9" secondAttribute="leading" id="GOt-ed-Khh"/>
                                                 <constraint firstItem="XBU-7r-pwn" firstAttribute="leading" secondItem="K93-pH-Ba9" secondAttribute="leading" constant="8" id="GV0-FY-WyF"/>
-                                                <constraint firstAttribute="bottom" secondItem="pZs-b8-2Np" secondAttribute="bottom" constant="8" id="KfD-2z-JIt"/>
-                                                <constraint firstAttribute="trailing" secondItem="pZs-b8-2Np" secondAttribute="trailing" constant="8" id="LMk-gW-6Gs"/>
-                                                <constraint firstAttribute="bottom" secondItem="pZs-b8-2Np" secondAttribute="bottom" constant="8" id="YuL-4s-Mlr"/>
-                                                <constraint firstItem="QTr-Q8-jXt" firstAttribute="top" secondItem="XBU-7r-pwn" secondAttribute="top" id="Zof-VH-eMg"/>
-                                                <constraint firstAttribute="bottom" secondItem="pZs-b8-2Np" secondAttribute="bottom" constant="73.5" id="bGA-06-3kp"/>
-                                                <constraint firstItem="QTr-Q8-jXt" firstAttribute="centerY" secondItem="XBU-7r-pwn" secondAttribute="centerY" id="eDF-So-Vbw"/>
-                                                <constraint firstItem="pZs-b8-2Np" firstAttribute="top" secondItem="XBU-7r-pwn" secondAttribute="bottom" constant="8" id="mIc-Ye-Hjv"/>
+                                                <constraint firstItem="cTi-TP-9y1" firstAttribute="trailing" secondItem="pZs-b8-2Np" secondAttribute="trailing" id="IdA-oH-dJ6"/>
+                                                <constraint firstAttribute="bottom" secondItem="pZs-b8-2Np" secondAttribute="bottom" id="YuL-4s-Mlr"/>
+                                                <constraint firstItem="pZs-b8-2Np" firstAttribute="top" secondItem="K93-pH-Ba9" secondAttribute="top" id="lso-pu-6iF"/>
                                                 <constraint firstItem="eMS-a0-w40" firstAttribute="centerY" secondItem="pZs-b8-2Np" secondAttribute="centerY" id="rbD-4e-bRl"/>
+                                                <constraint firstItem="cTi-TP-9y1" firstAttribute="top" secondItem="pZs-b8-2Np" secondAttribute="top" id="tr1-3B-yzY"/>
+                                                <constraint firstItem="cTi-TP-9y1" firstAttribute="leading" secondItem="pZs-b8-2Np" secondAttribute="leading" id="vjH-Au-7ik"/>
                                                 <constraint firstItem="XBU-7r-pwn" firstAttribute="top" secondItem="K93-pH-Ba9" secondAttribute="top" constant="8" id="xLP-Ej-ZKo"/>
                                                 <constraint firstItem="eMS-a0-w40" firstAttribute="centerX" secondItem="pZs-b8-2Np" secondAttribute="centerX" id="zlz-MZ-cQC"/>
                                             </constraints>
-                                            <variation key="default">
-                                                <mask key="constraints">
-                                                    <exclude reference="DU8-Fm-Jjp"/>
-                                                    <exclude reference="KfD-2z-JIt"/>
-                                                    <exclude reference="LMk-gW-6Gs"/>
-                                                    <exclude reference="bGA-06-3kp"/>
-                                                    <exclude reference="Zof-VH-eMg"/>
-                                                    <exclude reference="eDF-So-Vbw"/>
-                                                </mask>
-                                            </variation>
                                         </tableViewCellContentView>
                                         <connections>
                                             <outlet property="camaraRollImageView" destination="pZs-b8-2Np" id="wRa-ve-Lwr"/>
@@ -429,7 +420,7 @@
                                 </variation>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="2PW-2V-byW" firstAttribute="leading" secondItem="RXa-GT-wda" secondAttribute="leading" constant="5" id="0NQ-OG-5WA"/>
                             <constraint firstAttribute="trailing" secondItem="oiO-Cz-3yC" secondAttribute="trailing" id="27N-te-6vQ"/>

--- a/masterch/LooKBackViewController.swift
+++ b/masterch/LooKBackViewController.swift
@@ -417,7 +417,7 @@ extension LooKBackViewController: UITableViewDelegate, UITableViewDataSource, TT
         cell.postImageView.image = nil
         if let postImageName = postData.objectForKey("image1") as? String {
             cell.imageViewHeightConstraint.constant = 150.0
-            cell.postImageView.layer.cornerRadius = 5.0
+//            cell.postImageView.layer.cornerRadius = 5.0
             let postImageFile = NCMBFile.fileWithName(postImageName, data: nil) as! NCMBFile
             SDWebImageManager.sharedManager().imageCache.queryDiskCacheForKey(postImageFile.name, done: { (image, SDImageCacheType) in
                 if let image = image {

--- a/masterch/LookBack.storyboard
+++ b/masterch/LookBack.storyboard
@@ -56,7 +56,7 @@
                                                     </variation>
                                                 </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="kek-mK-lLJ">
-                                                    <rect key="frame" x="8" y="102" width="584" height="150"/>
+                                                    <rect key="frame" x="0.0" y="102" width="600" height="150"/>
                                                     <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="150" id="amZ-Fl-4VS"/>
@@ -152,7 +152,7 @@
                                                 </button>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="kek-mK-lLJ" secondAttribute="trailing" constant="8" id="0Fj-Pl-n4x"/>
+                                                <constraint firstAttribute="trailing" secondItem="kek-mK-lLJ" secondAttribute="trailing" id="0Fj-Pl-n4x"/>
                                                 <constraint firstItem="6Mo-Nn-bmC" firstAttribute="leading" secondItem="qdv-Sz-tAX" secondAttribute="leading" constant="8" id="3cT-Dp-UnF"/>
                                                 <constraint firstItem="4AG-w9-V0f" firstAttribute="top" secondItem="kek-mK-lLJ" secondAttribute="bottom" constant="12" id="7dF-4P-7qa"/>
                                                 <constraint firstItem="kek-mK-lLJ" firstAttribute="top" secondItem="6Mo-Nn-bmC" secondAttribute="bottom" constant="8" id="HsN-06-Jz8"/>
@@ -169,7 +169,7 @@
                                                 <constraint firstItem="ZQu-c7-rdJ" firstAttribute="top" secondItem="qdv-Sz-tAX" secondAttribute="top" constant="8" id="luI-64-VVc"/>
                                                 <constraint firstItem="hfc-QH-jMM" firstAttribute="centerY" secondItem="ZQu-c7-rdJ" secondAttribute="centerY" id="mHZ-UQ-xte"/>
                                                 <constraint firstItem="utK-82-vF0" firstAttribute="centerY" secondItem="hfc-QH-jMM" secondAttribute="centerY" id="nUh-xn-Lso"/>
-                                                <constraint firstItem="kek-mK-lLJ" firstAttribute="leading" secondItem="qdv-Sz-tAX" secondAttribute="leading" constant="8" id="qAM-oB-uEC"/>
+                                                <constraint firstItem="kek-mK-lLJ" firstAttribute="leading" secondItem="qdv-Sz-tAX" secondAttribute="leading" id="qAM-oB-uEC"/>
                                                 <constraint firstItem="utK-82-vF0" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="hfc-QH-jMM" secondAttribute="trailing" constant="8" id="sL4-NC-kJj"/>
                                                 <constraint firstItem="AbR-Dm-6P6" firstAttribute="width" secondItem="4AG-w9-V0f" secondAttribute="width" id="vOI-HI-tkj"/>
                                                 <constraint firstItem="hfc-QH-jMM" firstAttribute="leading" secondItem="ZQu-c7-rdJ" secondAttribute="trailing" constant="6" id="wfg-Ng-axt"/>

--- a/masterch/PostDetailTableViewCell.xib
+++ b/masterch/PostDetailTableViewCell.xib
@@ -207,7 +207,7 @@
                         </connections>
                     </button>
                     <imageView clipsSubviews="YES" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="nje-0u-yaf">
-                        <rect key="frame" x="10" y="91" width="580" height="0.0"/>
+                        <rect key="frame" x="0.0" y="91" width="600" height="0.0"/>
                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="height" id="czl-3Q-ake"/>
@@ -233,12 +233,12 @@
                     <constraint firstAttribute="trailingMargin" secondItem="x8c-gL-2FI" secondAttribute="trailing" constant="140" id="7mM-Wa-UfC"/>
                     <constraint firstAttribute="trailingMargin" secondItem="wgI-7M-TQ0" secondAttribute="trailing" id="9Q0-is-HXz"/>
                     <constraint firstItem="wgI-7M-TQ0" firstAttribute="top" secondItem="tHj-ur-unf" secondAttribute="bottom" constant="23" id="9bf-X7-12K"/>
-                    <constraint firstItem="nje-0u-yaf" firstAttribute="leading" secondItem="vQ9-WZ-f3c" secondAttribute="leading" constant="10" id="AdE-v8-7MM"/>
+                    <constraint firstItem="nje-0u-yaf" firstAttribute="leading" secondItem="vQ9-WZ-f3c" secondAttribute="leading" id="AdE-v8-7MM"/>
                     <constraint firstAttribute="bottomMargin" secondItem="YsN-f5-Uyf" secondAttribute="bottom" constant="-1" id="Clt-92-M1P"/>
                     <constraint firstAttribute="trailingMargin" secondItem="tHj-ur-unf" secondAttribute="trailing" id="DMJ-ov-Ldq"/>
                     <constraint firstItem="YsN-f5-Uyf" firstAttribute="leading" secondItem="vR6-re-bwi" secondAttribute="trailing" constant="123" id="DfQ-92-9UN"/>
                     <constraint firstAttribute="leadingMargin" secondItem="LaX-o5-sCd" secondAttribute="leading" id="DvF-vc-fxw"/>
-                    <constraint firstAttribute="trailing" secondItem="nje-0u-yaf" secondAttribute="trailing" constant="10" id="EP4-c6-tXi"/>
+                    <constraint firstAttribute="trailing" secondItem="nje-0u-yaf" secondAttribute="trailing" id="EP4-c6-tXi"/>
                     <constraint firstAttribute="leadingMargin" secondItem="NbS-U0-qOu" secondAttribute="leading" id="EaI-Rx-ynU"/>
                     <constraint firstItem="vR6-re-bwi" firstAttribute="centerX" secondItem="vQ9-WZ-f3c" secondAttribute="centerX" id="GvV-Fv-mgd"/>
                     <constraint firstItem="vR6-re-bwi" firstAttribute="top" secondItem="nje-0u-yaf" secondAttribute="bottom" constant="4" id="H3i-Em-sJ3"/>

--- a/masterch/SetProfileViewController.swift
+++ b/masterch/SetProfileViewController.swift
@@ -51,8 +51,8 @@ class SetProfileViewController: UIViewController {
 
         selfIntroductionTextView.layer.borderWidth = 1.0
         selfIntroductionTextView.layer.borderColor = UIColor.lightGrayColor().CGColor
-        selfIntroductionTextView.layer.cornerRadius = 5.0
-        
+//        selfIntroductionTextView.layer.cornerRadius = 5.0
+
 //        文字数カウントのために入力後の通知を受け取れるようにする
         NSNotificationCenter.defaultCenter().addObserver(self,
             selector:#selector(SetProfileViewController.userNameTextFieldDidChange(_:)),

--- a/masterch/SubmitViewController.swift
+++ b/masterch/SubmitViewController.swift
@@ -352,7 +352,7 @@ extension SubmitViewController: UIImagePickerControllerDelegate, UINavigationCon
         postImageView.frame = CGRectMake(0, postTextView.contentSize.height+10, self.postTextView.contentSize.width*0.9, self.postTextView.contentSize.width*0.9)
         postImageView.center.x = self.postTextView.bounds.width/2
         self.postImageView.contentMode = UIViewContentMode.ScaleAspectFill
-        postImageView.layer.cornerRadius = 5.0
+//        postImageView.layer.cornerRadius = 5.0
         postImageView.clipsToBounds = true
 
         self.postTextView.addSubview(postImageView)

--- a/masterch/Title.storyboard
+++ b/masterch/Title.storyboard
@@ -16,7 +16,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" misplaced="YES" image="logoTitle" translatesAutoresizingMaskIntoConstraints="NO" id="fM4-fv-nK7">
+                            <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="logoTitle" translatesAutoresizingMaskIntoConstraints="NO" id="fM4-fv-nK7">
                                 <rect key="frame" x="128" y="160" width="158" height="42"/>
                             </imageView>
                         </subviews>


### PR DESCRIPTION
 - カレンダーviewの背景画像をそのログの対象のユーザーのホーム画像をブラーしたものに
 - 投稿内容の画像を横幅をデバイスギリギリまでに変更